### PR TITLE
Merge lhe weights

### DIFF
--- a/AnalysisTools/plugins/GenZZCleaner.cc
+++ b/AnalysisTools/plugins/GenZZCleaner.cc
@@ -99,20 +99,19 @@ void GenZZCleaner::produce(edm::Event& iEvent,
       CCandPtr c = in->ptrAt(i);
 
       float mZ1 = c->daughter(0)->mass();
-      if(mZ1 < z1MassMin || mZ1 > z1MassMax)
-        continue;
       float mZ2 = c->daughter(1)->mass();
-      if(mZ2 < z2MassMin || mZ2 > z2MassMax)
-        continue;
 
       float dz1 = std::abs(mZ1 - 91.1876);
       float dz2 = std::abs(mZ2 - 91.1876);
-
       float betterDZ = (dz1 < dz2 ? dz1 : dz2);
 
       bool best = betterDZ < bestDZ;
-
       if(!best)
+        continue;
+
+      if(mZ1 < z1MassMin || mZ1 > z1MassMax)
+        continue;
+      if(mZ2 < z2MassMin || mZ2 > z2MassMax)
         continue;
 
       std::vector<const Cand*> daughters;

--- a/AnalysisTools/python/templates/GenZZBase.py
+++ b/AnalysisTools/python/templates/GenZZBase.py
@@ -1,10 +1,10 @@
-from UWVV.AnalysisTools.templates.ZPlusXBaseFlow import ZPlusXBaseFlow
+from UWVV.AnalysisTools.templates.ZPlusXBaseFlow import ZPlusXBaseFlowGen
 from UWVV.Utilities.helpers import mapObjects, parseChannels
 
 import FWCore.ParameterSet.Config as cms
 
 
-class GenZZBase(ZPlusXBaseFlow):
+class GenZZBase(ZPlusXBaseFlowGen):
     def __init__(self, *args, **kwargs):
         super(GenZZBase, self).__init__(*args, **kwargs)
 

--- a/AnalysisTools/python/templates/ZPlusXBaseFlow.py
+++ b/AnalysisTools/python/templates/ZPlusXBaseFlow.py
@@ -24,10 +24,7 @@ class ZPlusXBaseFlow(AnalysisFlowBase):
             'PATCandViewShallowCloneCombiner',
             decay = cms.string('{0}@+ {0}@-'.format(step.getObjTagString('e'))),
             roles = cms.vstring('e1', 'e2'),
-            cut = cms.string('daughter("e1").pt > 7 && '
-                             'daughter("e2").pt > 7 && '
-                             'abs(daughter("e1").eta) < 2.5 && '
-                             'abs(daughter("e2").eta) < 2.5'),
+            cut = cms.string(self.__class__.getZEECuts()),
             checkCharge = cms.bool(True),
             setPdgId = cms.int32(23),
             )
@@ -36,13 +33,43 @@ class ZPlusXBaseFlow(AnalysisFlowBase):
             'PATCandViewShallowCloneCombiner',
             decay = cms.string('{0}@+ {0}@-'.format(step.getObjTagString('m'))),
             roles = cms.vstring('m1', 'm2'),
-            cut = cms.string('daughter("m1").masterClone.pt > 5 && '
-                             'daughter("m2").masterClone.pt > 5 && '
-                             'abs(daughter("m1").masterClone.eta) < 2.4 && '
-                             'abs(daughter("m2").masterClone.eta) < 2.4'),
+            cut = cms.string(self.__class__.getZMMCuts()),
             checkCharge = cms.bool(True),
             setPdgId = cms.int32(23),
             )
 
         step.addModule("zEECreation", zEEMod, 'ee')
         step.addModule("zMuMuCreation", zMuMuMod, 'mm')
+
+
+    @classmethod
+    def getZEECuts(cls):
+        return ('daughter("e1").pt > 7 && '
+                'daughter("e2").pt > 7 && '
+                'abs(daughter("e1").eta) < 2.5 && '
+                'abs(daughter("e2").eta) < 2.5')
+
+
+    @classmethod
+    def getZMMCuts(cls):
+        return ('daughter("m1").pt > 5 && '
+                    'daughter("m2").pt > 5 && '
+                    'abs(daughter("m1").eta) < 2.4 && '
+                    'abs(daughter("m2").eta) < 2.4')
+
+
+class ZPlusXBaseFlowGen(ZPlusXBaseFlow):
+    @classmethod
+    def getZEECuts(cls):
+        return ('daughter("e1").pt > 5 && '
+                'daughter("e2").pt > 5 && '
+                'abs(daughter("e1").eta) < 2.5 && '
+                'abs(daughter("e2").eta) < 2.5')
+
+
+    @classmethod
+    def getZMMCuts(cls):
+        return ('daughter("m1").pt > 5 && '
+                'daughter("m2").pt > 5 && '
+                'abs(daughter("m1").eta) < 2.5 && '
+                'abs(daughter("m2").eta) < 2.5')

--- a/Ntuplizer/interface/BranchManager.h
+++ b/Ntuplizer/interface/BranchManager.h
@@ -16,12 +16,14 @@
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
 #include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 // UWVV
 #include "UWVV/Ntuplizer/interface/EventInfo.h"
 #include "UWVV/Ntuplizer/interface/BranchHolder.h"
 #include "UWVV/Ntuplizer/interface/FunctionLibrary.h"
 #include "UWVV/Utilities/interface/helpers.h"
+#include "UWVV/DataFormats/interface/DressedGenParticle.h"
 
 namespace uwvv
 {
@@ -308,19 +310,43 @@ namespace uwvv
     {
       return cand->daughter(1)->pt() > cand->daughter(0)->pt();
     }
+  template<> bool
+    BranchManager<CompositeDaughter<reco::GenParticle, reco::GenParticle> >::daughtersNeedReorder(const edm::Ptr<pat::CompositeCandidate>& cand) const
+    {
+      return cand->daughter(1)->pt() > cand->daughter(0)->pt();
+    }
+  template<> bool
+    BranchManager<CompositeDaughter<DressedGenParticle, DressedGenParticle> >::daughtersNeedReorder(const edm::Ptr<pat::CompositeCandidate>& cand) const
+    {
+      return cand->daughter(1)->pt() > cand->daughter(0)->pt();
+    }
 
   // 4e and 4mu candidates should be ordered by Z compatibility
   template<> bool
     BranchManager<CompositeDaughter<CompositeDaughter<pat::Electron, pat::Electron>,
     CompositeDaughter<pat::Electron, pat::Electron> > >::daughtersNeedReorder(const edm::Ptr<pat::CompositeCandidate>& cand) const
     {
-      return helpers::zsNeedReorder<pat::Electron, pat::Electron>(cand);
+      return helpers::zsNeedReorder(cand);
     }
   template<> bool
     BranchManager<CompositeDaughter<CompositeDaughter<pat::Muon, pat::Muon>,
     CompositeDaughter<pat::Muon, pat::Muon> > >::daughtersNeedReorder(const edm::Ptr<pat::CompositeCandidate>& cand) const
     {
-      return helpers::zsNeedReorder<pat::Muon, pat::Muon>(cand);
+      return helpers::zsNeedReorder(cand);
+    }
+  template<> bool
+    BranchManager<CompositeDaughter<CompositeDaughter<reco::GenParticle, reco::GenParticle>,
+    CompositeDaughter<reco::GenParticle, reco::GenParticle> > >::daughtersNeedReorder(const edm::Ptr<pat::CompositeCandidate>& cand) const
+    {
+      return std::abs(cand->daughter(0)->daughter(0)->pdgId()) == std::abs(cand->daughter(1)->daughter(0)->pdgId()) &&
+        helpers::zsNeedReorder(cand);
+    }
+  template<> bool
+    BranchManager<CompositeDaughter<CompositeDaughter<DressedGenParticle, DressedGenParticle>,
+    CompositeDaughter<DressedGenParticle, DressedGenParticle> > >::daughtersNeedReorder(const edm::Ptr<pat::CompositeCandidate>& cand) const
+    {
+      return std::abs(cand->daughter(0)->daughter(0)->pdgId()) == std::abs(cand->daughter(1)->daughter(0)->pdgId()) &&
+        helpers::zsNeedReorder(cand);
     }
 
 } // namespace

--- a/Ntuplizer/interface/FunctionLibrary.h
+++ b/Ntuplizer/interface/FunctionLibrary.h
@@ -126,24 +126,25 @@ namespace
 
                                  return out;
                                });
+
         addTo["lheWeights"] =
           std::function<FType>([](const edm::Ptr<T>& obj, uwvv::EventInfo& evt, const std::string& option)
                                {
                                   std::vector<float> out;
-                                 
-                                  if (!evt.lheEventInfo().isValid()) 
+
+                                  if (!evt.lheEventInfo().isValid())
                                     throw cms::Exception("ProductNotFound")
                                         << "Unable to open LHE event information";
-                                  
+
                                   unsigned long first_weight = 0;
                                   // Arbitrary choice, but 1000 weights would be pretty excessive
-                                  unsigned long last_weight = 1000; 
-                                  if (option != "") 
+                                  unsigned long last_weight = 1000;
+                                  if (option != "")
                                     {
                                       size_t pos = option.find(",");
                                       // If only 1 weight is specified, take it as the last weight (start at 0)
                                       if (pos == std::string::npos)
-                                        try 
+                                        try
                                           {
                                             last_weight = std::stoul(option);
                                           }
@@ -153,11 +154,11 @@ namespace
                                                 " for LHE weights. Error from ";
                                             throw std::runtime_error(message + e.what());
                                           }
-                                      else 
+                                      else
                                         {
                                           std::string begin = option.substr(0, pos);
                                           std::string end = option.substr(pos+1);
-                                          try 
+                                          try
                                             {
                                               first_weight = std::stoul(begin);
                                               last_weight = std::stoul(end);
@@ -171,7 +172,7 @@ namespace
                                         }
                                     }
                                   auto weights = evt.lheEventInfo()->weights();
-                                  for (unsigned long i = first_weight; i <  weights.size(); i++) 
+                                  for (unsigned long i = first_weight; i <  weights.size(); i++)
                                     {
                                       if (i == last_weight)
                                         break;
@@ -356,6 +357,124 @@ namespace
 
                                  return std::abs(deltaPhi(obj->phi(), phiJJ));
                                });
+
+        addTo["minLHEWeight"] =
+          std::function<FType>([](const edm::Ptr<T>& obj, uwvv::EventInfo& evt, const std::string& option)
+                               {
+                                  if (!evt.lheEventInfo().isValid())
+                                    throw cms::Exception("ProductNotFound")
+                                        << "Unable to open LHE event information";
+
+                                  unsigned long first_weight = 0;
+                                  // Arbitrary choice, but 1000 weights would be pretty excessive
+                                  unsigned long last_weight = 1000;
+                                  if (option != "")
+                                    {
+                                      size_t pos = option.find(",");
+                                      // If only 1 weight is specified, take it as the last weight (start at 0)
+                                      if (pos == std::string::npos)
+                                        try
+                                          {
+                                            last_weight = std::stoul(option);
+                                          }
+                                        catch (const std::exception& e)
+                                          {
+                                            std::string message = "Unable to parse option " + option +
+                                                " for LHE weights. Error from ";
+                                            throw std::runtime_error(message + e.what());
+                                          }
+                                      else
+                                        {
+                                          std::string begin = option.substr(0, pos);
+                                          std::string end = option.substr(pos+1);
+                                          try
+                                            {
+                                              first_weight = std::stoul(begin);
+                                              last_weight = std::stoul(end);
+                                            }
+                                          catch (const std::exception& e)
+                                            {
+                                              std::string message = "Unable to parse option " + option +
+                                                  " for LHE weights. Error from ";
+                                              throw std::runtime_error(message + e.what());
+                                            }
+                                        }
+                                    }
+
+                                  float minWeight = 999.;
+
+                                  auto weights = evt.lheEventInfo()->weights();
+                                  for (unsigned long i = first_weight; i <  weights.size(); i++)
+                                    {
+                                      if (i == last_weight)
+                                        break;
+                                      if(i == 5 || i == 7) // some scale weights don't count, apparently
+                                        continue;
+                                      if(weights[i].wgt < minWeight)
+                                        minWeight = weights[i].wgt;
+                                    }
+
+                                  return minWeight;
+                                });
+
+        addTo["maxLHEWeight"] =
+          std::function<FType>([](const edm::Ptr<T>& obj, uwvv::EventInfo& evt, const std::string& option)
+                               {
+                                  if (!evt.lheEventInfo().isValid())
+                                    throw cms::Exception("ProductNotFound")
+                                        << "Unable to open LHE event information";
+
+                                  unsigned long first_weight = 0;
+                                  // Arbitrary choice, but 1000 weights would be pretty excessive
+                                  unsigned long last_weight = 1000;
+                                  if (option != "")
+                                    {
+                                      size_t pos = option.find(",");
+                                      // If only 1 weight is specified, take it as the last weight (start at 0)
+                                      if (pos == std::string::npos)
+                                        try
+                                          {
+                                            last_weight = std::stoul(option);
+                                          }
+                                        catch (const std::exception& e)
+                                          {
+                                            std::string message = "Unable to parse option " + option +
+                                                " for LHE weights. Error from ";
+                                            throw std::runtime_error(message + e.what());
+                                          }
+                                      else
+                                        {
+                                          std::string begin = option.substr(0, pos);
+                                          std::string end = option.substr(pos+1);
+                                          try
+                                            {
+                                              first_weight = std::stoul(begin);
+                                              last_weight = std::stoul(end);
+                                            }
+                                          catch (const std::exception& e)
+                                            {
+                                              std::string message = "Unable to parse option " + option +
+                                                  " for LHE weights. Error from ";
+                                              throw std::runtime_error(message + e.what());
+                                            }
+                                        }
+                                    }
+
+                                  float maxWeight = -999.;
+
+                                  auto weights = evt.lheEventInfo()->weights();
+                                  for (unsigned long i = first_weight; i <  weights.size(); i++)
+                                    {
+                                      if (i == last_weight)
+                                        break;
+                                      if(i == 5 || i == 7) // some scale weights don't count, apparently
+                                        continue;
+                                      if(weights[i].wgt > maxWeight)
+                                        maxWeight = weights[i].wgt;
+                                    }
+
+                                  return maxWeight;
+                                });
       }
     };
 

--- a/Ntuplizer/plugins/TreeGenerator.cc
+++ b/Ntuplizer/plugins/TreeGenerator.cc
@@ -1,12 +1,12 @@
-/////////////////////////////////////////////////////////////////////////////    
-//                                                                         //    
-//    TreeGenerator                                                        //    
-//                                                                         //    
-//    A builder of ntuples from composite candidates.                      //    
-//                                                                         //    
-//    Nate Woods, U. Wisconsin                                             //    
-//                                                                         //    
-/////////////////////////////////////////////////////////////////////////////    
+/////////////////////////////////////////////////////////////////////////////
+//                                                                         //
+//    TreeGenerator                                                        //
+//                                                                         //
+//    A builder of ntuples from composite candidates.                      //
+//                                                                         //
+//    Nate Woods, U. Wisconsin                                             //
+//                                                                         //
+/////////////////////////////////////////////////////////////////////////////
 
 
 //STL
@@ -24,6 +24,7 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 #include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 // ROOT
 #include "TTree.h"
@@ -37,7 +38,7 @@
 
 using namespace uwvv;
 
-template<class T> 
+template<class T>
 class TreeGenerator : public edm::one::EDAnalyzer<edm::one::SharedResources>
 {
   // If this is a particle candidate, we can make branches directly from it
@@ -69,7 +70,7 @@ class TreeGenerator : public edm::one::EDAnalyzer<edm::one::SharedResources>
 template<class T>
 TreeGenerator<T>::TreeGenerator(const edm::ParameterSet& config) :
   candToken(consumes<edm::View<Cand> >(config.getParameter<edm::InputTag>("src"))),
-  ntupleName(config.exists("ntupleName") ? 
+  ntupleName(config.exists("ntupleName") ?
              config.getParameter<std::string>("ntupleName") : "ntuple"),
   tree(makeTree()),
   evtInfo(consumesCollector(), config.getParameter<edm::ParameterSet>("eventParams"))
@@ -77,10 +78,10 @@ TreeGenerator<T>::TreeGenerator(const edm::ParameterSet& config) :
   usesResource("TFileService");
 
   const edm::ParameterSet& branchParams = config.getParameter<edm::ParameterSet>("branches");
-  branches = 
+  branches =
     std::unique_ptr<BranchManager<T> >(new BranchManager<T>("", tree, branchParams));
 
-  const edm::ParameterSet& triggers = config.getParameter<edm::ParameterSet>("triggers");  
+  const edm::ParameterSet& triggers = config.getParameter<edm::ParameterSet>("triggers");
   triggerBranches = std::unique_ptr<TriggerBranches>(new TriggerBranches(consumesCollector(),
                                                                          triggers, tree));
 }
@@ -115,54 +116,54 @@ TreeGenerator<T>::analyze(const edm::Event &event,
 }
 
 
-typedef TreeGenerator<CompositeDaughter<CompositeDaughter<pat::Electron, pat::Electron>, 
-                                        CompositeDaughter<pat::Electron, pat::Electron> 
-                                        > 
+typedef TreeGenerator<CompositeDaughter<CompositeDaughter<pat::Electron, pat::Electron>,
+                                        CompositeDaughter<pat::Electron, pat::Electron>
+                                        >
                       > TreeGeneratorEEEE;
-typedef TreeGenerator<CompositeDaughter<CompositeDaughter<pat::Electron, pat::Electron>, 
-                                        CompositeDaughter<pat::Muon, pat::Muon> 
-                                        > 
+typedef TreeGenerator<CompositeDaughter<CompositeDaughter<pat::Electron, pat::Electron>,
+                                        CompositeDaughter<pat::Muon, pat::Muon>
+                                        >
                       > TreeGeneratorEEMuMu;
-typedef TreeGenerator<CompositeDaughter<CompositeDaughter<pat::Muon, pat::Muon>, 
-                                        CompositeDaughter<pat::Muon, pat::Muon> 
-                                        > 
+typedef TreeGenerator<CompositeDaughter<CompositeDaughter<pat::Muon, pat::Muon>,
+                                        CompositeDaughter<pat::Muon, pat::Muon>
+                                        >
                       > TreeGeneratorMuMuMuMu;
 typedef TreeGenerator<CompositeDaughter<CompositeDaughter<pat::Electron, pat::Electron>,
                                         pat::Electron
-                                        > 
+                                        >
                       > TreeGeneratorEEE;
 typedef TreeGenerator<CompositeDaughter<CompositeDaughter<pat::Muon, pat::Muon>,
                                         pat::Muon
-                                        > 
+                                        >
                       > TreeGeneratorMuMuMu;
 typedef TreeGenerator<CompositeDaughter<CompositeDaughter<pat::Electron, pat::Electron>,
                                         pat::Muon
-                                        > 
+                                        >
                       > TreeGeneratorEEMu;
 typedef TreeGenerator<CompositeDaughter<CompositeDaughter<pat::Muon, pat::Muon>,
                                         pat::Electron
-                                        > 
+                                        >
                       > TreeGeneratorEMuMu;
 typedef TreeGenerator<CompositeDaughter<pat::Electron, pat::Electron> > TreeGeneratorEE;
 typedef TreeGenerator<CompositeDaughter<pat::Muon, pat::Muon> > TreeGeneratorMuMu;
 typedef TreeGenerator<pat::Electron> TreeGeneratorE;
 typedef TreeGenerator<pat::Muon> TreeGeneratorMu;
 
-typedef TreeGenerator<CompositeDaughter<CompositeDaughter<reco::GenParticle, reco::GenParticle>, 
-                                        CompositeDaughter<reco::GenParticle, reco::GenParticle> 
-                                        > 
+typedef TreeGenerator<CompositeDaughter<CompositeDaughter<reco::GenParticle, reco::GenParticle>,
+                                        CompositeDaughter<reco::GenParticle, reco::GenParticle>
+                                        >
                       > GenTreeGeneratorZZ;
 typedef TreeGenerator<CompositeDaughter<CompositeDaughter<reco::GenParticle, reco::GenParticle>,
                                         reco::GenParticle
-                                        > 
+                                        >
                       > GenTreeGeneratorWZ;
-typedef TreeGenerator<CompositeDaughter<CompositeDaughter<DressedGenParticle, DressedGenParticle>, 
-                                        CompositeDaughter<DressedGenParticle, DressedGenParticle> 
-                                        > 
+typedef TreeGenerator<CompositeDaughter<CompositeDaughter<DressedGenParticle, DressedGenParticle>,
+                                        CompositeDaughter<DressedGenParticle, DressedGenParticle>
+                                        >
                       > GenDressedTreeGeneratorZZ;
 typedef TreeGenerator<CompositeDaughter<CompositeDaughter<DressedGenParticle, DressedGenParticle>,
                                         DressedGenParticle
-                                        > 
+                                        >
                       > GenDressedTreeGeneratorWZ;
 
 

--- a/Ntuplizer/python/templates/eventBranches.py
+++ b/Ntuplizer/python/templates/eventBranches.py
@@ -31,7 +31,7 @@ eventBranches = cms.PSet(
 
 lheScaleWeightBranches = cms.PSet(
     vFloats = cms.PSet(
-        lheWeights = cms.vstring('lheWeights::0,9'),
+        scaleWeights = cms.vstring('lheWeights::0,9'),
         ),
     floats = cms.PSet(
         minScaleWeight = cms.string('minLHEWeight::0,9'),
@@ -41,7 +41,8 @@ lheScaleWeightBranches = cms.PSet(
 
 lheScaleAndPDFWeightBranches = cms.PSet(
     vFloats = cms.PSet(
-        lheWeights = cms.vstring('lheWeights::0,111'),
+        scaleWeights = cms.vstring('lheWeights::0,9'),
+        pdfWeights = cms.vstring('lheWeights::9,111'),
         ),
     floats = cms.PSet(
         minScaleWeight = cms.string('minLHEWeight::0,9'),
@@ -53,13 +54,14 @@ lheScaleAndPDFWeightBranches = cms.PSet(
 
 lheAllWeightBranches = cms.PSet(
     vFloats = cms.PSet(
-        lheWeights = cms.vstring('lheWeights'),
+        scaleWeights = cms.vstring('lheWeights::0,9'),
+        pdfWeights = cms.vstring('lheWeights::9,9999'),
         ),
     floats = cms.PSet(
         minScaleWeight = cms.string('minLHEWeight::0,9'),
         maxScaleWeight = cms.string('maxLHEWeight::0,9'),
-        minPDFWeight = cms.string('minLHEWeight::9,1000'),
-        maxPDFWeight = cms.string('maxLHEWeight::9,1000'),
+        minPDFWeight = cms.string('minLHEWeight::9,9999'),
+        maxPDFWeight = cms.string('maxLHEWeight::9,9999'),
         ),
     )
 

--- a/Ntuplizer/python/templates/eventBranches.py
+++ b/Ntuplizer/python/templates/eventBranches.py
@@ -33,11 +33,33 @@ lheScaleWeightBranches = cms.PSet(
     vFloats = cms.PSet(
         lheWeights = cms.vstring('lheWeights::0,9'),
         ),
+    floats = cms.PSet(
+        minScaleWeight = cms.string('minLHEWeight::0,9'),
+        maxScaleWeight = cms.string('maxLHEWeight::0,9'),
+        ),
     )
 
-lheWeightBranches = cms.PSet(
+lheScaleAndPDFWeightBranches = cms.PSet(
+    vFloats = cms.PSet(
+        lheWeights = cms.vstring('lheWeights::0,111'),
+        ),
+    floats = cms.PSet(
+        minScaleWeight = cms.string('minLHEWeight::0,9'),
+        maxScaleWeight = cms.string('maxLHEWeight::0,9'),
+        minPDFWeight = cms.string('minLHEWeight::9,111'),
+        maxPDFWeight = cms.string('maxLHEWeight::9,111'),
+        ),
+    )
+
+lheAllWeightBranches = cms.PSet(
     vFloats = cms.PSet(
         lheWeights = cms.vstring('lheWeights'),
+        ),
+    floats = cms.PSet(
+        minScaleWeight = cms.string('minLHEWeight::0,9'),
+        maxScaleWeight = cms.string('maxLHEWeight::0,9'),
+        minPDFWeight = cms.string('minLHEWeight::9,1000'),
+        maxPDFWeight = cms.string('maxLHEWeight::9,1000'),
         ),
     )
 

--- a/Utilities/interface/helpers.h
+++ b/Utilities/interface/helpers.h
@@ -59,14 +59,13 @@ namespace uwvv
       return zMassDistance(v.mass());
     }
 
-    // Return true if the first daughter is 
+    // Return true if the first daughter is
     // farther from the nominal Z mass than the second daughter
-    template<class T12, class T34>
-      bool zsNeedReorder(const edm::Ptr<pat::CompositeCandidate>& cand)
+    bool zsNeedReorder(const edm::Ptr<pat::CompositeCandidate>& cand)
     {
       math::XYZTLorentzVector p4a = cand->daughter(0)->p4();
       math::XYZTLorentzVector p4b = cand->daughter(1)->p4();
-      
+
       return std::abs(p4b.mass() - 91.1876) < std::abs(p4a.mass() - 91.1876);
     }
 

--- a/Utilities/scripts/submitZZNtuples.sh
+++ b/Utilities/scripts/submitZZNtuples.sh
@@ -131,19 +131,24 @@ then
         echo Submitting ZZ MC Ntuples as UWVVZZ_MC_"$ID"
 
         # reHLT
-        python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'Graviton2PBToZZTo4L*' 'ZZTo4L*amcatnlo*'  'DYJetsToLL_M-50*amcatnlo*' 'TTJets*' 'GluGluHToZZTo4L_M125*pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mc_"$ID".sh UWVVZZ_MC_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 genInfo=1 globalTag="$GT_MC"
+        python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'ZZTo4L*amcatnlo*'  'DYJetsToLL_M-50*amcatnlo*' 'TTJets*' 'GluGluHToZZTo4L_M125*pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mc_"$ID".sh UWVVZZ_MC_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 genInfo=1 globalTag="$GT_MC" genLeptonType=dressedHPFS
 
         nohup bash /data/nawoods/uwvvZZ_mc_"$ID".sh &
 
         # no HLT
-        python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8' 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'GluGluToContinToZZTo2e2tau*' 'GluGluToContinToZZTo2mu2tau*' 'ZZTo4L*powheg*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_"$ID".sh UWVVZZ_MC_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 genInfo=1 globalTag="$GT_MC"
+        python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8' 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'GluGluToContinToZZTo2e2tau*' 'GluGluToContinToZZTo2mu2tau*' 'ZZTo4L*powheg*' 'WWZ*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_"$ID".sh UWVVZZ_MC_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 genInfo=1 globalTag="$GT_MC" genLeptonType=dressedHPFS
 
         nohup bash /data/nawoods/uwvvZZ_mcNoHLT_"$ID".sh &
 
         # alternative production
-        python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'ZZJJTo4L_EWK_13TeV-madgraph-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial_"$ID".sh UWVVZZ_MC_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 genInfo=1 globalTag="$GT_MC"
+        python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'ZZJJTo4L_EWK_13TeV-madgraph-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial_"$ID".sh UWVVZZ_MC_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 genInfo=1 globalTag="$GT_MC" genLeptonType=dressedHPFS
 
         nohup bash /data/nawoods/uwvvZZ_mcSpecial_"$ID".sh &
+
+        # more alternative production
+        python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1 --samples 'TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial2_"$ID".sh UWVVZZ_MC_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 genInfo=1 globalTag="$GT_MC" genLeptonType=dressedHPFS
+
+        nohup bash /data/nawoods/uwvvZZ_mcSpecial2_"$ID".sh &
 
         # with systematic shifts
         if [ "$SYST" ]
@@ -155,7 +160,7 @@ then
 
             nohup bash /data/nawoods/uwvvZZ_mc_eScaleUp_"$ID".sh &
 
-            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_eScaleUp_"$ID".sh UWVVZZ_MC_ESCALEUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eScaleShift=1 globalTag="$GT_MC"
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' 'WWZ*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_eScaleUp_"$ID".sh UWVVZZ_MC_ESCALEUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eScaleShift=1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mcNoHLT_eScaleUp_"$ID".sh &
 
@@ -163,12 +168,16 @@ then
 
             nohup bash /data/nawoods/uwvvZZ_mcSpecial_eScaleUp_"$ID".sh &
 
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1 --samples 'TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial2_eScaleUp_"$ID".sh UWVVZZ_MC_ESCALEUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 eScaleShift=1 globalTag="$GT_MC"
+
+            nohup bash /data/nawoods/uwvvZZ_mcSpecial2_eScaleUp_"$ID".sh &
+
             # EES-
             python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'ZZTo4L*amcatnlo*' 'GluGluHToZZTo4L_M125*pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mc_eScaleDn_"$ID".sh UWVVZZ_MC_ESCALEDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eScaleShift=-1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mc_eScaleDn_"$ID".sh &
 
-            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_eScaleDn_"$ID".sh UWVVZZ_MC_ESCALEDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eScaleShift=-1 globalTag="$GT_MC"
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' 'WWZ*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_eScaleDn_"$ID".sh UWVVZZ_MC_ESCALEDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eScaleShift=-1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mcNoHLT_eScaleDn_"$ID".sh &
 
@@ -176,12 +185,16 @@ then
 
             nohup bash /data/nawoods/uwvvZZ_mcSpecial_eScaleDn_"$ID".sh &
 
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1 --samples 'TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial2_eScaleDn_"$ID".sh UWVVZZ_MC_ESCALEDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 eScaleShift=-1 globalTag="$GT_MC"
+
+            nohup bash /data/nawoods/uwvvZZ_mcSpecial2_eScaleDn_"$ID".sh &
+
             # EER+ (rho)
             python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'ZZTo4L*amcatnlo*' 'GluGluHToZZTo4L_M125*pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mc_eRhoResUp_"$ID".sh UWVVZZ_MC_ERHORESUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eRhoResShift=1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mc_eRhoResUp_"$ID".sh &
 
-            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_eRhoResUp_"$ID".sh UWVVZZ_MC_ERHORESUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eRhoResShift=1 globalTag="$GT_MC"
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' 'WWZ*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_eRhoResUp_"$ID".sh UWVVZZ_MC_ERHORESUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eRhoResShift=1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mcNoHLT_eRhoResUp_"$ID".sh &
 
@@ -189,12 +202,16 @@ then
 
             nohup bash /data/nawoods/uwvvZZ_mcSpecial_eRhoResUp_"$ID".sh &
 
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1 --samples 'TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial2_eRhoResUp_"$ID".sh UWVVZZ_MC_ERHORESUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 eRhoResShift=1 globalTag="$GT_MC"
+
+            nohup bash /data/nawoods/uwvvZZ_mcSpecial2_eRhoResUp_"$ID".sh &
+
             # EER- (rho)
             python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'ZZTo4L*amcatnlo*' 'GluGluHToZZTo4L_M125*pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mc_eRhoResDn_"$ID".sh UWVVZZ_MC_ERHORESDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eRhoResShift=-1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mc_eRhoResDn_"$ID".sh &
 
-            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_eRhoResDn_"$ID".sh UWVVZZ_MC_ERHORESDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eRhoResShift=-1 globalTag="$GT_MC"
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' 'WWZ*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_eRhoResDn_"$ID".sh UWVVZZ_MC_ERHORESDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 eRhoResShift=-1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mcNoHLT_eRhoResDn_"$ID".sh &
 
@@ -202,12 +219,16 @@ then
 
             nohup bash /data/nawoods/uwvvZZ_mcSpecial_eRhoResDn_"$ID".sh &
 
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1 --samples 'TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial2_eRhoResDn_"$ID".sh UWVVZZ_MC_ERHORESDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 eRhoResShift=-1 globalTag="$GT_MC"
+
+            nohup bash /data/nawoods/uwvvZZ_mcSpecial2_eRhoResDn_"$ID".sh &
+
             # EER+ (phi)
             python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'ZZTo4L*amcatnlo*' 'GluGluHToZZTo4L_M125*pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mc_ePhiResUp_"$ID".sh UWVVZZ_MC_EPHIRESUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 ePhiResShift=1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mc_ePhiResUp_"$ID".sh &
 
-            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_ePhiResUp_"$ID".sh UWVVZZ_MC_EPHIRESUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 ePhiResShift=1 globalTag="$GT_MC"
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' 'WWZ*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_ePhiResUp_"$ID".sh UWVVZZ_MC_EPHIRESUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eeee,eemm' isMC=1 eCalib=1 muCalib=1 ePhiResShift=1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mcNoHLT_ePhiResUp_"$ID".sh &
 
@@ -215,12 +236,16 @@ then
 
             nohup bash /data/nawoods/uwvvZZ_mcSpecial_ePhiResUp_"$ID".sh &
 
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1 --samples 'TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial2_ePhiResUp_"$ID".sh UWVVZZ_MC_EPHIRESUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 ePhiResShift=1 globalTag="$GT_MC"
+
+            nohup bash /data/nawoods/uwvvZZ_mcSpecial2_ePhiResUp_"$ID".sh &
+
             # MES/MER+
             python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'ZZTo4L*amcatnlo*' 'GluGluHToZZTo4L_M125*pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mc_mClosureUp_"$ID".sh UWVVZZ_MC_MCLOSUREUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eemm,mmmm' isMC=1 eCalib=1 muCalib=1 mClosureShift=1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mc_mClosureUp_"$ID".sh &
 
-            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_mClosureUp_"$ID".sh UWVVZZ_MC_MCLOSUREUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eemm,mmmm' isMC=1 eCalib=1 muCalib=1 mClosureShift=1 globalTag="$GT_MC"
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' 'WWZ*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_mClosureUp_"$ID".sh UWVVZZ_MC_MCLOSUREUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eemm,mmmm' isMC=1 eCalib=1 muCalib=1 mClosureShift=1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mcNoHLT_mClosureUp_"$ID".sh &
 
@@ -228,18 +253,26 @@ then
 
             nohup bash /data/nawoods/uwvvZZ_mcSpecial_mClosureUp_"$ID".sh &
 
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1 --samples 'TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial2_mClosureUp_"$ID".sh UWVVZZ_MC_MCLOSUREUP_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 mClosureShift=1 globalTag="$GT_MC"
+
+            nohup bash /data/nawoods/uwvvZZ_mcSpecial2_mClosureUp_"$ID".sh &
+
             # MES/MER-
             python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'ZZTo4L*amcatnlo*' 'GluGluHToZZTo4L_M125*pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mc_mClosureDn_"$ID".sh UWVVZZ_MC_MCLOSUREDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eemm,mmmm' isMC=1 eCalib=1 muCalib=1 mClosureShift=-1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mc_mClosureDn_"$ID".sh &
 
-            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_mClosureDn_"$ID".sh UWVVZZ_MC_MCLOSUREDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eemm,mmmm' isMC=1 eCalib=1 muCalib=1 mClosureShift=-1 globalTag="$GT_MC"
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1 --samples 'GluGluToContinToZZTo4*' 'GluGluToContinToZZTo2e2mu*' 'ZZTo4L*powheg*' 'WWZ*' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcNoHLT_mClosureDn_"$ID".sh UWVVZZ_MC_MCLOSUREDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eemm,mmmm' isMC=1 eCalib=1 muCalib=1 mClosureShift=-1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mcNoHLT_mClosureDn_"$ID".sh &
 
             python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14-v1 --samples 'ZZJJTo4L_EWK_13TeV-madgraph-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial_mClosureDn_"$ID".sh UWVVZZ_MC_MCLOSUREDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='eemm,mmmm' isMC=1 eCalib=1 muCalib=1 mClosureShift=-1 globalTag="$GT_MC"
 
             nohup bash /data/nawoods/uwvvZZ_mcSpecial_mClosureDn_"$ID".sh &
+
+            python Utilities/scripts/submitJobs.py --campaign RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1 --samples 'TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8' --filesPerJob 2 -o /data/nawoods/uwvvZZ_mcSpecial2_mClosureDn_"$ID".sh UWVVZZ_MC_MCLOSUREDN_"$ID" Ntuplizer/test/ntuplize_cfg.py channels='zz' isMC=1 eCalib=1 muCalib=1 mClosureShift=-1 globalTag="$GT_MC"
+
+            nohup bash /data/nawoods/uwvvZZ_mcSpecial2_mClosureDn_"$ID".sh &
         fi
     fi
 


### PR DESCRIPTION
A few changes to add to nwoods/UWVV#11. Adds branches for minimum and maximum scale and PDF weights, puts scale and PDF weights in separate vector branches where applicable, and adds an option for the vector of weights (scale + just one set of PDF weights). Note that the `lheWeights` command line options in `ntuplize_cfg.py` are reordered so that larger numbers include more weights (i.e. 1 is scale only, 2 is scale + one PDF set, >=3 is scale + all PDF sets). 

Those things are in the last two commits; the rest are stuff added to master since your PR.