### PR TITLE
Linker fun times

### DIFF
--- a/Ntuplizer/interface/FunctionLibrary.h
+++ b/Ntuplizer/interface/FunctionLibrary.h
@@ -9,7 +9,7 @@
 
 #include "UWVV/Ntuplizer/interface/EventInfo.h"
 #include "UWVV/Ntuplizer/interface/StringFunctionMaker.h"
-#include "UWVV/Utilities/src/helpers.cc"
+#include "UWVV/Utilities/interface/helpers.h"
 #include "UWVV/DataFormats/interface/DressedGenParticle.h"
 
 #include "DataFormats/PatCandidates/interface/Electron.h"
@@ -112,7 +112,7 @@ namespace
 
                                  return out;
                                });
-        
+
         addTo["jetCSVv2"] =
           std::function<FType>([](const edm::Ptr<T>& obj, uwvv::EventInfo& evt, const std::string& option)
                                {

--- a/Utilities/interface/helpers.h
+++ b/Utilities/interface/helpers.h
@@ -18,14 +18,24 @@ namespace uwvv
   namespace helpers
   {
     // Get an object's four-momentum with FSR included (if any).
+    // Note: p4WithoutFSR<pat::CompositeCandidate> is defined in helpers.cc
     template<class T>
-      math::XYZTLorentzVector p4WithoutFSR(const T& cand);
+    math::XYZTLorentzVector p4WithoutFSR(const T& cand)
+    {
+      // if it's not a composite, FSR isn't included by definition
+      if(cand.numberOfDaughters() == 0)
+        return cand.p4();
 
-    template<>
-      math::XYZTLorentzVector p4WithoutFSR(const pat::CompositeCandidate& cand);
+      const pat::CompositeCandidate& ccand = dynamic_cast<const pat::CompositeCandidate&>(cand);
+      return p4WithoutFSR(ccand);
+    }
 
     template<class T>
-      math::XYZTLorentzVector p4WithoutFSR(const edm::Ptr<T>& cand);
+    math::XYZTLorentzVector p4WithoutFSR(const edm::Ptr<T>& cand)
+    {
+      return p4WithoutFSR(*cand);
+    }
+
 
     float zMassDistance(const float m);
 

--- a/Utilities/src/helpers.cc
+++ b/Utilities/src/helpers.cc
@@ -1,7 +1,3 @@
-#ifndef UWVV_Utilities_helpers_cc
-#define UWVV_Utilities_helpers_cc
-
-
 #include "UWVV/Utilities/interface/helpers.h"
 
 namespace uwvv
@@ -9,33 +5,15 @@ namespace uwvv
 
   namespace helpers
   {
-    // Get an object's four-momentum with FSR included (if any).
-    template<class T>
-      math::XYZTLorentzVector p4WithoutFSR(const T& cand)
-      {
-        // if it's not a composite, FSR isn't included by definition
-        if(cand.numberOfDaughters() == 0)
-          return cand.p4();
-
-        const pat::CompositeCandidate& ccand = dynamic_cast<const pat::CompositeCandidate&>(cand);
-        return p4WithoutFSR(ccand);
-      }
-
     template<>
-      math::XYZTLorentzVector p4WithoutFSR(const pat::CompositeCandidate& cand)
-      {
-        math::XYZTLorentzVector out = p4WithoutFSR(*(cand.daughter(0)->masterClone().get()));
-        if(cand.numberOfDaughters() >= 2)
-          out += p4WithoutFSR(*(cand.daughter(1)->masterClone().get()));
+    math::XYZTLorentzVector p4WithoutFSR(const pat::CompositeCandidate& cand)
+    {
+      math::XYZTLorentzVector out = p4WithoutFSR(*(cand.daughter(0)->masterClone().get()));
+      if(cand.numberOfDaughters() >= 2)
+        out += p4WithoutFSR(*(cand.daughter(1)->masterClone().get()));
 
-        return out;
-      }
-
-    template<class T>
-      math::XYZTLorentzVector p4WithoutFSR(const edm::Ptr<T>& cand)
-      {
-        return p4WithoutFSR(*cand);
-      }
+      return out;
+    }
 
     float zMassDistance(const float m)
     {
@@ -80,7 +58,5 @@ namespace uwvv
       return false;
     }
   } // namespace helpers
-
 } // namespace uwvv
 
-#endif // header guard


### PR DESCRIPTION
This should fix the issues we discussed offline. The crux of the issue is that template implementations have to be done in helpers.h so the compiler knows to build the right versions everywhere, while fully specified function definitions (_including fully specialized template functions_) have to be done in helpers.cc so they are only defined once. 